### PR TITLE
Prepare webtemplate2 for when pip will be deprecating the old setup.py method in version 25.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42", "wheel", "Django>=2.2]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
See: https://github.com/pypa/pip/issues/6334 for more information